### PR TITLE
feature/set plugin window title

### DIFF
--- a/napari_aicssegmentation/_dock_widget.py
+++ b/napari_aicssegmentation/_dock_widget.py
@@ -9,8 +9,11 @@ Replace code below according to your needs.
 from napari_plugin_engine import napari_hook_implementation
 from qtpy.QtWidgets import QWidget, QHBoxLayout, QPushButton
 
-# class name -> window title, e.g.,
-# class MyWidget -> napari-aicssegmentation: My Widget
+"""
+The class name here gets converted to title case and gets displayed as both the title of the
+plugin window ("napari-aicssegmentation: QWidget Class Name") and the title displayed
+in the app menu dropdown (Plugins -> Add Dock Widget -> napari-aicssegmentation -> QWidget Class Name).
+"""
 class AllenCellStructureSegmenter(QWidget):
     # your QWidget.__init__ can optionally request the napari viewer instance
     # in one of two ways:

--- a/napari_aicssegmentation/_dock_widget.py
+++ b/napari_aicssegmentation/_dock_widget.py
@@ -9,8 +9,9 @@ Replace code below according to your needs.
 from napari_plugin_engine import napari_hook_implementation
 from qtpy.QtWidgets import QWidget, QHBoxLayout, QPushButton
 
-
-class MyWidget(QWidget):
+# class name -> window title, e.g.,
+# class MyWidget -> napari-aicssegmentation: My Widget
+class AllenCellStructureSegmenter(QWidget):
     # your QWidget.__init__ can optionally request the napari viewer instance
     # in one of two ways:
     # 1. use a parameter called `napari_viewer`, as done here
@@ -31,4 +32,4 @@ class MyWidget(QWidget):
 
 @napari_hook_implementation
 def napari_experimental_provide_dock_widget():
-    return MyWidget
+    return AllenCellStructureSegmenter

--- a/napari_aicssegmentation/_function.py
+++ b/napari_aicssegmentation/_function.py
@@ -50,7 +50,3 @@ def image_arithmetic(
 ) -> "LayerDataTuple":
     """Adds, subtracts, multiplies, or divides two same-shaped image layers."""
     return (operation.value(layerA, layerB), {"colormap": "turbo"})
-
-
-def test_sanity():
-    assert True


### PR DESCRIPTION
Resolves #6 
Resolves #7

### Starting the plugin from the menu:
Ideally we would just see Plugins -> Add Dock Widget -> Allen Cell Segmenter, but it seems Napari automatically nests dock widgets (like Allen Cell Structure Segmenter) and functions ("threshold" and "image arithmetic" -- which are examples from the plugin cookie cutter which we can/should remove at some point) under the name of the package (napari-aicssegmentation in this case). I'm not sure we can change that.

![image](https://user-images.githubusercontent.com/12690133/108279286-3adf9700-7131-11eb-9ae4-176ccd7f4f46.png)

### View plugin as a separate window or as a docked widget:
Again, I couldn't find a way to remove the package name (napari-aicssegmentation) from the window title -- maybe one of you know how.
![image](https://user-images.githubusercontent.com/12690133/108279198-0ec41600-7131-11eb-974c-31bf1a5def62.png)

![image](https://user-images.githubusercontent.com/12690133/108279238-23a0a980-7131-11eb-8e37-105b73cf966f.png)

### Notes
* I also removed a sanity check from _function.py per Jamie's request.


**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
