### PR TITLE
Disconnect controller events

### DIFF
--- a/napari_aicssegmentation/_tests/core/controller_test.py
+++ b/napari_aicssegmentation/_tests/core/controller_test.py
@@ -8,10 +8,15 @@ from napari_aicssegmentation.core.view_manager import ViewManager
 from napari_aicssegmentation.core.view import View
 
 
+class MockController(Controller):
+    def index():
+        pass
+
+
 class TestController:
     def setup_method(self):
         self._mock_application: MagicMock = create_autospec(IApplication)
-        self._controller = Controller(self._mock_application)
+        self._controller = MockController(self._mock_application)
 
     def test_properties(self):
         # Arrange

--- a/napari_aicssegmentation/_tests/core/router_test.py
+++ b/napari_aicssegmentation/_tests/core/router_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from unittest import mock
 from unittest.mock import MagicMock, create_autospec
-from napari_aicssegmentation.core.router import Router, IApplication
+from napari_aicssegmentation.core.router import Router, IApplication, Controller
 
 
 class TestRouter:
@@ -23,3 +23,13 @@ class TestRouter:
         self._router.workflow_steps()
         # Assert
         mock_workflow_steps_controller.return_value.index.assert_called_once()
+
+    @mock.patch("napari_aicssegmentation.core.router.WorkflowStepsController")
+    def test_navigate_cleanup_previous_controller(self, mock_workflow_steps_controller: MagicMock):
+        # Arrange
+        mock_controller = create_autospec(Controller)
+        self._router._controller = mock_controller
+        # Act
+        self._router.workflow_steps()
+        # Assert
+        mock_controller.cleanup.assert_called_once()

--- a/napari_aicssegmentation/controller/_interfaces.py
+++ b/napari_aicssegmentation/controller/_interfaces.py
@@ -4,10 +4,6 @@ from napari_aicssegmentation.model.channel import Channel
 
 class IWorkflowSelectController(ABC):
     @abstractmethod
-    def index(self):
-        pass
-
-    @abstractmethod
     def select_layer(self, layer_name: str):
         """
         Handle user selection of a layer
@@ -50,10 +46,6 @@ class IWorkflowSelectController(ABC):
 
 
 class IWorkflowStepsController(ABC):
-    @abstractmethod
-    def index(self):
-        pass
-
     @abstractmethod
     def close_workflow(self):
         """

--- a/napari_aicssegmentation/controller/workflow_select_controller.py
+++ b/napari_aicssegmentation/controller/workflow_select_controller.py
@@ -44,6 +44,10 @@ class WorkflowSelectController(Controller, IWorkflowSelectController):
         self.model.workflows = self._workflow_engine.workflow_definitions
         self._view.load_model(self.model)
 
+    def cleanup(self):
+        # Disconnect events so that controller instances aren't kept around
+        self.viewer.events.layers_change.disconnect(self._handle_layers_change)
+
     def select_layer(self, layer_name: str):
         self.model.selected_layer = next(filter(lambda layer: layer.name == layer_name, self.get_layers()), None)
         self.model.channels = self._layer_reader.get_channels(self.model.selected_layer)

--- a/napari_aicssegmentation/core/controller.py
+++ b/napari_aicssegmentation/core/controller.py
@@ -1,6 +1,6 @@
 import napari
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from napari_aicssegmentation.core.state import State
 from napari_aicssegmentation.core.view import View
 from napari_aicssegmentation.util.debug_utils import debug_class
@@ -16,6 +16,17 @@ class Controller(ABC):
         if application is None:
             raise ValueError("application")
         self._application = application
+
+    @abstractmethod
+    def index(self):
+        pass
+
+    def cleanup(self):
+        """
+        Perform cleanup operations such as disconnecting events
+        Override in child class if needed
+        """
+        pass
 
     @property
     def state(self) -> State:

--- a/napari_aicssegmentation/core/router.py
+++ b/napari_aicssegmentation/core/router.py
@@ -3,6 +3,7 @@ from napari_aicssegmentation.util.debug_utils import debug_class
 from napari_aicssegmentation.controller.workflow_select_controller import WorkflowSelectController
 from napari_aicssegmentation.controller.workflow_steps_controller import WorkflowStepsController
 from napari_aicssegmentation.core.layer_reader import LayerReader
+from napari_aicssegmentation.core.controller import Controller
 from ._interfaces import IApplication, IRouter
 
 
@@ -19,9 +20,15 @@ class Router(IRouter):
         self._workflow_engine = WorkflowEngine()
 
     def workflow_selection(self):
-        self._controller = WorkflowSelectController(self._application, self._layer_reader, self._workflow_engine)
-        self._controller.index()
+        controller = WorkflowSelectController(self._application, self._layer_reader, self._workflow_engine)
+        self._handle_navigation(controller)
 
     def workflow_steps(self):
-        self._controller = WorkflowStepsController(self._application, self._workflow_engine)
+        controller = WorkflowStepsController(self._application, self._workflow_engine)
+        self._handle_navigation(controller)
+
+    def _handle_navigation(self, controller: Controller):
+        if self._controller:
+            self._controller.cleanup()
+        self._controller = controller
         self._controller.index()

--- a/napari_aicssegmentation/widgets/workflow_step_widget.py
+++ b/napari_aicssegmentation/widgets/workflow_step_widget.py
@@ -27,7 +27,7 @@ class WorkflowStepWidget(QWidget):
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
-        self._step = step
+        
         if step.function.parameters is None:
             no_param_label = QLabel("No parameters needed")
             no_param_label.setAlignment(Qt.AlignCenter)

--- a/napari_aicssegmentation/widgets/workflow_step_widget.py
+++ b/napari_aicssegmentation/widgets/workflow_step_widget.py
@@ -27,7 +27,7 @@ class WorkflowStepWidget(QWidget):
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
-        
+
         if step.function.parameters is None:
             no_param_label = QLabel("No parameters needed")
             no_param_label.setAlignment(Qt.AlignCenter)

--- a/napari_aicssegmentation/widgets/workflow_step_widget.py
+++ b/napari_aicssegmentation/widgets/workflow_step_widget.py
@@ -27,7 +27,7 @@ class WorkflowStepWidget(QWidget):
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
-
+        self._step = step
         if step.function.parameters is None:
             no_param_label = QLabel("No parameters needed")
             no_param_label.setAlignment(Qt.AlignCenter)


### PR DESCRIPTION
Fix for #66 

- Add cleanup method to controller(s)
- Disconnect event handler that was keeping controller instances around longer than they should
