### PR TITLE
set 3 digit precision for slider/spinboxes

### DIFF
--- a/napari_aicssegmentation/widgets/float_slider.py
+++ b/napari_aicssegmentation/widgets/float_slider.py
@@ -1,0 +1,18 @@
+from PyQt5.QtWidgets import QDoubleSpinBox
+import magicgui.widgets
+
+class FloatSlider(magicgui.widgets.FloatSlider):
+    """
+    Custom FloatSlider widget
+    This class is used to avoid accessing the underlying FloatSlider's private API 
+    from other parts of the plugin
+    TODO remove once features are exposed on the magicgui FloatSlider
+         see https://github.com/napari/magicgui/issues/226
+    """
+
+    def setDecimals(self, precision: int):
+        """
+        Set decimal precision (number of decimals) for the slider
+        """
+        spinbox: QDoubleSpinBox = self._widget._readout_widget
+        spinbox.setDecimals(precision)

--- a/napari_aicssegmentation/widgets/float_slider.py
+++ b/napari_aicssegmentation/widgets/float_slider.py
@@ -1,6 +1,7 @@
 from PyQt5.QtWidgets import QDoubleSpinBox
 import magicgui.widgets
 
+
 class FloatSlider(magicgui.widgets.FloatSlider):
     """
     Custom FloatSlider widget

--- a/napari_aicssegmentation/widgets/workflow_step_widget.py
+++ b/napari_aicssegmentation/widgets/workflow_step_widget.py
@@ -2,13 +2,13 @@ import copy
 from typing import List, Union
 
 from aicssegmentation.workflow import WorkflowStep, FunctionParameter, WidgetType
-from magicgui.widgets import FloatSlider, Slider
+from magicgui.widgets import Slider
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QLabel, QVBoxLayout, QWidget
-
 from napari_aicssegmentation.widgets.collapsible_box import CollapsibleBox
 from napari_aicssegmentation.widgets.form import Form, FormRow
 from napari_aicssegmentation.util.ui_utils import UiUtils
+from .float_slider import FloatSlider
 
 
 class WorkflowStepWidget(QWidget):
@@ -72,23 +72,22 @@ class WorkflowStepWidget(QWidget):
         if default_value < param.min_value or default_value > param.max_value:
             raise ValueError("Default value outside of min-max range")
 
-        # Build dictionary of keyword args for slider widgets
-        kwargs = dict()
-        kwargs["step"] = param.increment
-        kwargs["max"] = param.max_value
-        kwargs["min"] = param.min_value
-        kwargs["value"] = default_value
-
-        magicgui_widget = None
+        magicgui_slider = None
         if param.data_type == "float":
-            magicgui_widget = FloatSlider(**kwargs)
+            magicgui_slider = FloatSlider()
+            magicgui_slider.setDecimals(3)             
         if param.data_type == "int":
-            magicgui_widget = Slider(**kwargs)
-        magicgui_widget.changed.connect(self._update_parameter_inputs)
-        magicgui_widget.native.setStyleSheet("QWidget { background-color: transparent; }")
-        magicgui_widget.native.setObjectName(param_name)
+            magicgui_slider = Slider()
 
-        self.form_rows.append(FormRow(param_label, magicgui_widget))
+        magicgui_slider.min = param.min_value
+        magicgui_slider.max = param.max_value
+        magicgui_slider.step = param.increment     
+        magicgui_slider.value = default_value
+        magicgui_slider.changed.connect(self._update_parameter_inputs)
+        magicgui_slider.native.setStyleSheet("QWidget { background-color: transparent; }")
+        magicgui_slider.native.setObjectName(param_name)
+
+        self.form_rows.append(FormRow(param_label, magicgui_slider))
 
     def _add_dropdown(
         self, param_name: str, param_label: str, param: FunctionParameter, default_value: Union[str, bool, int, float]

--- a/napari_aicssegmentation/widgets/workflow_step_widget.py
+++ b/napari_aicssegmentation/widgets/workflow_step_widget.py
@@ -75,13 +75,13 @@ class WorkflowStepWidget(QWidget):
         magicgui_slider = None
         if param.data_type == "float":
             magicgui_slider = FloatSlider()
-            magicgui_slider.setDecimals(3)             
+            magicgui_slider.setDecimals(3)
         if param.data_type == "int":
             magicgui_slider = Slider()
 
         magicgui_slider.min = param.min_value
         magicgui_slider.max = param.max_value
-        magicgui_slider.step = param.increment     
+        magicgui_slider.step = param.increment
         magicgui_slider.value = default_value
         magicgui_slider.changed.connect(self._update_parameter_inputs)
         magicgui_slider.native.setStyleSheet("QWidget { background-color: transparent; }")


### PR DESCRIPTION
For #75 

-  Fix for supporting 3 digit precision on slider float parameters. This is a workaround until decimal precision is supported by the magicgui widget.
