### PR TITLE
Feature/save workflow

### DIFF
--- a/napari_aicssegmentation/_tests/controller/workflow_steps_controller_test.py
+++ b/napari_aicssegmentation/_tests/controller/workflow_steps_controller_test.py
@@ -8,7 +8,7 @@ from napari_aicssegmentation.core.state import State
 from napari_aicssegmentation.core.view_manager import ViewManager
 from napari_aicssegmentation.model.channel import Channel
 from napari_aicssegmentation.model.segmenter_model import SegmenterModel
-from aicssegmentation.workflow import WorkflowEngine
+from aicssegmentation.workflow import WorkflowEngine, WorkflowStep
 
 
 class TestWorkflowStepsController:
@@ -22,10 +22,10 @@ class TestWorkflowStepsController:
         type(self._mock_application).view_manager = PropertyMock(return_value=self._mock_view_manager)
         self._model = SegmenterModel()
         type(self._mock_state).segmenter_model = PropertyMock(return_value=self._model)
-        self._workflow_engine: MagicMock = create_autospec(WorkflowEngine)
+        self._mock_workflow_engine: MagicMock = create_autospec(WorkflowEngine)
 
         with mock.patch("napari_aicssegmentation.controller.workflow_steps_controller.WorkflowStepsView"):
-            self._controller = WorkflowStepsController(self._mock_application, self._workflow_engine)
+            self._controller = WorkflowStepsController(self._mock_application, self._mock_workflow_engine)
 
     def test_index(self):
         # Act
@@ -45,3 +45,13 @@ class TestWorkflowStepsController:
         # Assert
         self._controller.model.selected_channel == None
         self._mock_router.workflow_selection.assert_called_once()
+
+    def test_save_workflow(self):
+        # Arrange
+        steps = [create_autospec(WorkflowStep), create_autospec(WorkflowStep), create_autospec(WorkflowStep)]
+
+        # Act
+        self._controller.save_workflow(steps, "/path/to/file.json")
+
+        # Assert
+        self._mock_workflow_engine.save_workflow_definition.assert_called_once()

--- a/napari_aicssegmentation/_tests/view/workflow_steps_view_test.py
+++ b/napari_aicssegmentation/_tests/view/workflow_steps_view_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from unittest.mock import MagicMock, create_autospec
+from unittest import mock
+from unittest.mock import MagicMock, Mock, create_autospec
 from napari_aicssegmentation.view.workflow_steps_view import WorkflowStepsView, IWorkflowStepsController, SegmenterModel
 from aicssegmentation.workflow import WorkflowEngine
 
@@ -25,3 +26,9 @@ class TestWorkflowStepsView:
     def test_close_workflow_keep_layers(self):
         self._view.btn_close_keep.clicked.emit(False)
         self._mock_controller.close_workflow.assert_called_once()
+
+    @mock.patch("napari_aicssegmentation.view.workflow_steps_view.QFileDialog.getSaveFileName")
+    def test_save_workflow(self, mock_dialog_save: Mock):
+        mock_dialog_save.return_value = ("/path/to/file.json", "filters")
+        self._view.btn_save_workflow.clicked.emit(False)
+        self._mock_controller.save_workflow.assert_called_once()

--- a/napari_aicssegmentation/_tests/widgets/workflow_step_widget_test.py
+++ b/napari_aicssegmentation/_tests/widgets/workflow_step_widget_test.py
@@ -37,8 +37,8 @@ class TestWorkflowStepWidget:
             "scaling_param": [FunctionParameter("scaling", WidgetType.DROPDOWN, "str", options=["red", "blue"])]
         }
         function = SegmenterFunction("gaussian blur", "Gaussian blur", "my_function_name", "my_module_name", parameters)
-        parameter_defaults = {"scaling_param": ["blue"]}
-        step = WorkflowStep(WorkflowStepCategory.PRE_PROCESSING, function, 1, [2], parameter_defaults)
+        parameter_values = {"scaling_param": ["blue"]}
+        step = WorkflowStep(WorkflowStepCategory.PRE_PROCESSING, function, 1, [2], parameter_values)
 
         # Act
         widget = WorkflowStepWidget(step)
@@ -57,8 +57,8 @@ class TestWorkflowStepWidget:
             ]
         }
         function = SegmenterFunction("gaussian blur", "Gaussian blur", "my_function_name", "my_module_name", parameters)
-        parameter_defaults = {"scaling_param": ["blue", "green"]}
-        step = WorkflowStep(WorkflowStepCategory.PRE_PROCESSING, function, 1, [2], parameter_defaults)
+        parameter_values = {"scaling_param": ["blue", "green"]}
+        step = WorkflowStep(WorkflowStepCategory.PRE_PROCESSING, function, 1, [2], parameter_values)
 
         # Act
         widget = WorkflowStepWidget(step)
@@ -80,15 +80,15 @@ class TestWorkflowStepWidget:
             ],
         }
         function = SegmenterFunction("Test", "Test", "my_function_name", "my_module_name", parameters)
-        parameter_defaults = {"x": 5, "y": [1, 2]}
-        step = WorkflowStep(WorkflowStepCategory.PRE_PROCESSING, function, 1, [0], parameter_defaults)
+        parameter_values = {"x": 5, "y": [1, 2]}
+        step = WorkflowStep(WorkflowStepCategory.PRE_PROCESSING, function, 1, [0], parameter_values)
         widget = WorkflowStepWidget(step)
 
         # Act
         parameter_inputs = widget.get_parameter_inputs()
 
         # Assert
-        assert parameter_inputs == parameter_defaults
+        assert parameter_inputs == parameter_values
 
     def test_get_parameter_inputs_modified_params(self):
         # Arrange
@@ -100,9 +100,9 @@ class TestWorkflowStepWidget:
             ],
         }
         function = SegmenterFunction("Test", "Test", "my_function_name", "my_module_name", parameters)
-        parameter_defaults = {"x": 5, "y": [1, 2]}
+        parameter_values = {"x": 5, "y": [1, 2]}
         expected_values = {"x": 50, "y": [11, 22]}
-        step = WorkflowStep(WorkflowStepCategory.PRE_PROCESSING, function, 1, [0], parameter_defaults)
+        step = WorkflowStep(WorkflowStepCategory.PRE_PROCESSING, function, 1, [0], parameter_values)
         widget = WorkflowStepWidget(step)
 
         # Act

--- a/napari_aicssegmentation/controller/_interfaces.py
+++ b/napari_aicssegmentation/controller/_interfaces.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List
+
+from aicssegmentation.workflow.workflow_step import WorkflowStep
 from napari_aicssegmentation.model.channel import Channel
 
 
@@ -60,7 +62,7 @@ class IWorkflowStepsController(ABC):
         Run all steps in the active workflow.
 
         inputs
-            parameter_inputs (List[Dict]): Each dictionary has the same shape as a WorkflowStep.parameter_defaults
+            parameter_inputs (List[Dict]): Each dictionary has the same shape as a WorkflowStep.parameter_values
             dictionary, but with the parameter values obtained from the UI instead of default values.
         """
         pass
@@ -69,5 +71,16 @@ class IWorkflowStepsController(ABC):
     def cancel_run_all(self):
         """
         Cancel any ongoing full workflow run
+        """
+        pass
+
+    @abstractmethod
+    def save_workflow(self, steps: List[WorkflowStep], output_file_path: str):
+        """
+        Save the current workflow as a configuration file
+
+        inputs
+            steps (List[WorkflowStep]): List of Workflow steps to save as a Workflow
+            output_file_path (str): path to save the workflow file to
         """
         pass

--- a/napari_aicssegmentation/view/workflow_steps_view.py
+++ b/napari_aicssegmentation/view/workflow_steps_view.py
@@ -5,6 +5,7 @@ from aicssegmentation.workflow import WorkflowStepCategory
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QImage, QPixmap
 from PyQt5.QtWidgets import (
+    QFileDialog,
     QHBoxLayout,
     QLabel,
     QMessageBox,
@@ -131,11 +132,16 @@ class WorkflowStepsView(View):  # pragma: no-cover
         btn_close_workflow.setFixedWidth(120)
         btn_close_workflow.clicked.connect(self._btn_close_clicked)
 
+        btn_save_workflow = QPushButton("Save workflow")
+        btn_save_workflow.setFixedWidth(120)
+        btn_save_workflow.clicked.connect(self._btn_save_workflow_clicked)
+
         self.btn_run_all = QPushButton("Run all")
         self.btn_run_all.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         self.btn_run_all.clicked.connect(self._btn_run_all_clicked)
 
         layout.addWidget(btn_close_workflow)
+        layout.addWidget(btn_save_workflow)
         layout.addWidget(self.btn_run_all)
 
         self._layout.addLayout(layout)
@@ -207,3 +213,14 @@ class WorkflowStepsView(View):  # pragma: no-cover
     def _btn_run_all_cancel_clicked(self, checked: bool):
         self.btn_run_all.setText("Canceling...")
         self._controller.cancel_run_all()
+
+    def _btn_save_workflow_clicked(self, checked: bool):
+        file_path, _ = QFileDialog.getSaveFileName(self, 
+                                                  caption="Save workflow as...", 
+                                                  filter="Json file (*.json)", 
+                                                  options=QFileDialog.Option.DontUseNativeDialog | QFileDialog.Option.DontUseCustomDirectoryIcons)
+        # dialog = QFileDialog(self, caption="Save workflow as...", filter="Json file (*.json)")
+        # if dialog.exec():
+        #     dialog.getSaveFileName
+        if file_path:
+            print(file_path)

--- a/napari_aicssegmentation/widgets/workflow_step_widget.py
+++ b/napari_aicssegmentation/widgets/workflow_step_widget.py
@@ -39,7 +39,7 @@ class WorkflowStepWidget(QWidget):
             self.form_rows.append(FormRow("", label_no_param))
         else:
             for param_name, param_data in step.function.parameters.items():
-                default_values = step.parameter_defaults[param_name]
+                default_values = step.parameter_values[param_name]
                 self._add_param_rows(param_name, param_data, default_values)
 
         step_name = f"<span>{step.step_number}.&nbsp;{step.name}</span>"
@@ -47,16 +47,21 @@ class WorkflowStepWidget(QWidget):
         layout.addWidget(box)
 
     def get_workflow_step_with_inputs(self) -> WorkflowStep:
-        new_step = copy.deepcopy(self._step)        
+        """
+        Returns a new WorkflowStep object with updated parameter values to reflect user input
+        """
+        new_step = copy.deepcopy(self._step)
+        new_step.parameter_values = self.get_parameter_inputs()
+        return new_step
 
     def get_parameter_inputs(self) -> Dict[str, Any]:
         """
         Returns all parameter input values for the as a dictionary {param_name: param_value}
         """
-        if self._step.parameter_defaults is None:
+        if self._step.parameter_values is None:
             return None
 
-        parameter_inputs = copy.deepcopy(self._step.parameter_defaults)
+        parameter_inputs = copy.deepcopy(self._step.parameter_values)
 
         for parameter_name in parameter_inputs.keys():
             # If default values for this param came in a list, we need to save values

--- a/napari_aicssegmentation/widgets/workflow_step_widget.py
+++ b/napari_aicssegmentation/widgets/workflow_step_widget.py
@@ -46,6 +46,9 @@ class WorkflowStepWidget(QWidget):
         box = CollapsibleBox(step_name, Form(self.form_rows, (11, 5, 5, 5)))
         layout.addWidget(box)
 
+    def get_workflow_step_with_inputs(self) -> WorkflowStep:
+        new_step = copy.deepcopy(self._step)        
+
     def get_parameter_inputs(self) -> Dict[str, Any]:
         """
         Returns all parameter input values for the as a dictionary {param_name: param_value}

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requirements = [
     #"aicssegmentation >= 0.2.0",
     "aicssegmentation @ git+https://github.com/AllenCell/aics-segmentation.git@dev#egg=aicssegmentation",
     "magicgui >= 0.2.9",
-    "aicsimageio>=3.3.4,<4",
+    "aicsimageio>=3.3.6,<4",
     "opencv-python-headless>=4.5.1",
 ]
 
@@ -38,7 +38,7 @@ test_requirements = [
 ]
 
 dev_requirements = [
-    "black==19.10b0",
+    "black>=19.10b0",
     "bumpversion>=0.5.3",
     "coverage>=5.0a4",
     "docutils>=0.10,<0.16",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     "napari-plugin-engine>=0.1.4",
     "numpy",
     #"aicssegmentation >= 0.2.0",
-    "aicssegmentation @ git+https://github.com/AllenCell/aics-segmentation.git@dev#egg=aicssegmentation"
+    "aicssegmentation @ git+https://github.com/AllenCell/aics-segmentation.git@feature/save_workflow#egg=aicssegmentation"
     "magicgui >= 0.2.9",
     "aicsimageio>=3.3.4,<4",
     "opencv-python-headless>=4.5.1",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     "napari-plugin-engine>=0.1.4",
     "numpy",
     #"aicssegmentation >= 0.2.0",
-    "aicssegmentation @ git+https://github.com/AllenCell/aics-segmentation.git@feature/save_workflow#egg=aicssegmentation"
+    "aicssegmentation @ git+https://github.com/AllenCell/aics-segmentation.git@feature/save_workflow#egg=aicssegmentation",
     "magicgui >= 0.2.9",
     "aicsimageio>=3.3.4,<4",
     "opencv-python-headless>=4.5.1",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ requirements = [
     "napari>=0.4.8",    
     "napari-plugin-engine>=0.1.4",
     "numpy",
-    "aicssegmentation >= 0.2.0",
+    #"aicssegmentation >= 0.2.0",
+    "aicssegmentation @ git+https://github.com/AllenCell/aics-segmentation.git@dev#egg=aicssegmentation"
     "magicgui >= 0.2.9",
     "aicsimageio>=3.3.4,<4",
     "opencv-python-headless>=4.5.1",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     "napari-plugin-engine>=0.1.4",
     "numpy",
     #"aicssegmentation >= 0.2.0",
-    "aicssegmentation @ git+https://github.com/AllenCell/aics-segmentation.git@feature/save_workflow#egg=aicssegmentation",
+    "aicssegmentation @ git+https://github.com/AllenCell/aics-segmentation.git@dev#egg=aicssegmentation",
     "magicgui >= 0.2.9",
     "aicsimageio>=3.3.4,<4",
     "opencv-python-headless>=4.5.1",

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ def read(fname):
 # Add your dependencies in requirements.txt
 # Note: you can add test-specific requirements in tox.ini
 requirements = [
-    #"napari>=0.4.7",
-    "napari @ git+https://github.com/napari/napari.git@master#egg=napari",
+    "napari>=0.4.8",    
     "napari-plugin-engine>=0.1.4",
     "numpy",
     "aicssegmentation >= 0.2.0",


### PR DESCRIPTION
For #83 

- Add save workflow button and save as dialog (note: used QT dialog instead of native OS for a more consistent experience. MacOSX doesn't honor file type filters for example when using the native dialog)
- Save current workflow as json with current input parameters