### PR TITLE
Feature/channel names

### DIFF
--- a/napari_aicssegmentation/_tests/conftest.py
+++ b/napari_aicssegmentation/_tests/conftest.py
@@ -1,7 +1,7 @@
-from PyQt5.QtWidgets import QApplication
 import pytest
 import os
 
+from PyQt5.QtWidgets import QApplication
 
 @pytest.fixture(scope="session", autouse=True)
 def env_config():

--- a/napari_aicssegmentation/_tests/conftest.py
+++ b/napari_aicssegmentation/_tests/conftest.py
@@ -3,6 +3,7 @@ import os
 
 from PyQt5.QtWidgets import QApplication
 
+
 @pytest.fixture(scope="session", autouse=True)
 def env_config():
     """

--- a/napari_aicssegmentation/_tests/core/layer_reader_test.py
+++ b/napari_aicssegmentation/_tests/core/layer_reader_test.py
@@ -24,6 +24,12 @@ class TestLayerReader:
         # Assert
         assert channels is not None
         assert len(channels) == 4
+    
+    def test_get_channels_from_layer_source(self, resources_dir):
+        # Arrange
+        # TODO mock AICSImage
+        pass
+
 
     def test_get_channel_data_null_layer_fails(self):
         # Assert

--- a/napari_aicssegmentation/_tests/mocks.py
+++ b/napari_aicssegmentation/_tests/mocks.py
@@ -2,6 +2,7 @@ import numpy
 from typing import NamedTuple
 from napari.layers._source import Source
 
+
 class MockLayer(NamedTuple):
     """
     Custom mock: napari.Layer

--- a/napari_aicssegmentation/_tests/mocks.py
+++ b/napari_aicssegmentation/_tests/mocks.py
@@ -1,6 +1,6 @@
 import numpy
 from typing import NamedTuple
-
+from napari.layers._source import Source
 
 class MockLayer(NamedTuple):
     """
@@ -10,3 +10,4 @@ class MockLayer(NamedTuple):
     name: str
     data: numpy.ndarray = numpy.ones((4, 75, 100, 100))
     ndim: int = 4
+    source: Source = None

--- a/napari_aicssegmentation/controller/workflow_select_controller.py
+++ b/napari_aicssegmentation/controller/workflow_select_controller.py
@@ -78,7 +78,7 @@ class WorkflowSelectController(Controller, IWorkflowSelectController):
             + workflow_name,
         )
 
-        channel_data = self._layer_reader.get_channel_data(layer0, self.model.selected_channel.index)
+        channel_data = self._layer_reader.get_channel_data(self.model.selected_channel.index, layer0)
         self.model.active_workflow = self._workflow_engine.get_executable_workflow(workflow_name, channel_data)
 
         self.router.workflow_steps()

--- a/napari_aicssegmentation/controller/workflow_select_controller.py
+++ b/napari_aicssegmentation/controller/workflow_select_controller.py
@@ -78,7 +78,7 @@ class WorkflowSelectController(Controller, IWorkflowSelectController):
             + workflow_name,
         )
 
-        channel_data = self._layer_reader.get_channel_data(self.model.selected_channel.index, layer0)
+        channel_data = self._layer_reader.get_channel_data(layer0, self.model.selected_channel.index)
         self.model.active_workflow = self._workflow_engine.get_executable_workflow(workflow_name, channel_data)
 
         self.router.workflow_steps()

--- a/napari_aicssegmentation/core/layer_reader.py
+++ b/napari_aicssegmentation/core/layer_reader.py
@@ -8,6 +8,7 @@ from napari_aicssegmentation.model.channel import Channel
 
 log = logging.getLogger(__name__)
 
+
 class LayerReader:
     """
     Reader / Helper class to extract information out of Napari Layers
@@ -27,13 +28,15 @@ class LayerReader:
             try:
                 return self._get_channels_from_path(layer.source.path)
             except Exception as ex:
-                log.warning("Could not read image layer from source path even though a source path was provided."
-                            "Defaulting to reading from layer data (this is less accurate). \n"
-                            f"Error message: {ex}")
+                log.warning(
+                    "Could not read image layer from source path even though a source path was provided."
+                    "Defaulting to reading from layer data (this is less accurate). \n"
+                    f"Error message: {ex}"
+                )
 
         return self._get_channels_default(layer)
-    
-    def _get_channels_default(self, layer: Layer):
+
+    def _get_channels_default(self, layer: Layer) -> List[Channel]:
         img = AICSImage(layer.data)  # gives us a 6D image
 
         # we're expecting either STCZYX or STZCYX but we don't know for sure
@@ -72,9 +75,11 @@ class LayerReader:
             try:
                 return self._get_channel_data_from_path(channel_index, layer.source.path)
             except Exception as ex:
-                log.warning("Could not read image layer from source path even though a source path was provided."
-                            "Defaulting to reading from layer data (this is less accurate). \n"
-                            f"Error message: {ex}")
+                log.warning(
+                    "Could not read image layer from source path even though a source path was provided."
+                    "Defaulting to reading from layer data (this is less accurate). \n"
+                    f"Error message: {ex}"
+                )
 
         return self._get_channel_data_default(channel_index, layer)
 

--- a/napari_aicssegmentation/core/layer_reader.py
+++ b/napari_aicssegmentation/core/layer_reader.py
@@ -1,10 +1,12 @@
 import numpy as np
+import logging
 
 from typing import List
 from aicsimageio import AICSImage
 from napari.layers import Layer
 from napari_aicssegmentation.model.channel import Channel
 
+log = logging.getLogger(__name__)
 
 class LayerReader:
     """
@@ -14,10 +16,6 @@ class LayerReader:
     def get_channels(self, layer: Layer) -> List[Channel]:
         """
         Get the list of image channels from a layer
-        TODO this is a workaround for now and we just guess the Channel dimension based on its
-             location for most ome tiffs
-        TODO use aicsimageio to read image from the source file path and get channel names
-             once Napari exposes Image layer source (next release)
 
         inputs:
             layer (Layer): the Napari layer to read data from
@@ -25,6 +23,17 @@ class LayerReader:
         if layer is None:
             return None
 
+        if layer.source is not None and layer.source.path is not None:
+            try:
+                return self._get_channels_from_path(layer.source.path)
+            except Exception as ex:
+                log.warning("Could not read image layer from source path even though a source path was provided."
+                            "Defaulting to reading from layer data (this is less accurate). \n"
+                            f"Error message: {ex}")
+
+        return self._get_channels_default(layer)
+    
+    def _get_channels_default(self, layer: Layer):
         img = AICSImage(layer.data)  # gives us a 6D image
 
         # we're expecting either STCZYX or STZCYX but we don't know for sure
@@ -38,21 +47,38 @@ class LayerReader:
             channels.append(Channel(index))
         return channels
 
+    def _get_channels_from_path(self, image_path: str) -> List[Channel]:
+        img = AICSImage(image_path)
+
+        channels = list()
+        for index, name in enumerate(img.get_channel_names()):
+            channels.append(Channel(index, name))
+        return channels
+
     def get_channel_data(self, channel_index: int, layer: Layer) -> np.ndarray:
         """
         Get the image data from the layer for a given channel
-        TODO this is a workaround for now and we just guess the Channel dimension based on its
-             location for most ome tiffs
-        TODO use aicsimageio to read image from the source file path and get channel names
-             once Napari exposes Image layer source (next release)
 
         inputs:
             channel_index (int): index of the channel to load
             layer (Layer): the Napari layer to read data from
         """
+        if channel_index is None:
+            raise ValueError("channel_index is None")
         if layer is None:
-            raise ValueError("layer cannot be None")
+            raise ValueError("layer is None")
 
+        if layer.source is not None and layer.source.path is not None:
+            try:
+                return self._get_channel_data_from_path(channel_index, layer.source.path)
+            except Exception as ex:
+                log.warning("Could not read image layer from source path even though a source path was provided."
+                            "Defaulting to reading from layer data (this is less accurate). \n"
+                            f"Error message: {ex}")
+
+        return self._get_channel_data_default(channel_index, layer)
+
+    def _get_channel_data_default(self, channel_index: int, layer: Layer):
         img = AICSImage(layer.data)  # gives us a 6D image
 
         # we're expecting either STCZYX or STZCYX but we don't know for sure
@@ -61,3 +87,7 @@ class LayerReader:
             return img.data[0, 0, :, channel_index, :, :]  # STZCYX
 
         return img.data[0, 0, channel_index, :, :, :]  # STCZYX
+
+    def _get_channel_data_from_path(self, channel_index: int, image_path: str):
+        img = AICSImage(image_path)
+        return img.get_image_data("ZYX", T=0, S=0, C=channel_index)

--- a/napari_aicssegmentation/model/channel.py
+++ b/napari_aicssegmentation/model/channel.py
@@ -11,4 +11,4 @@ class Channel:
         if self.name is None or self.name.strip().isspace():
             return f"Channel {self.index}"
 
-        return f"Ch{self.index}. {self.name}"
+        return f"Ch{self.index}.  {self.name}"


### PR DESCRIPTION
For #54 

- Use layer source and aicsimageio to extract channel information if available. This will be a more robust way of dealing with channels.
- Display actual channel names from metadata for ome tiffs and other formats supported by aicsimageio
